### PR TITLE
Move react to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "example": "example"
   },
   "dependencies": {
-    "deep-equal": "^0.2.1",
+    "deep-equal": "^0.2.1"
+  },
+  "peerDependencies": {
     "react": "^0.11.2"
   },
   "devDependencies": {


### PR DESCRIPTION
This would let people use omniscient in a sub-module of a project and avoid packing duplicate versions of react.

For me, I'm making a small module to wrap omniscient so I can pack in goodies and adjust the interface in an app, and if I don't do this I end up with two versions of react packed up.
