### PR TITLE
add support for react@0.13.0-beta1

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "lodash.pick": "^3.0.0"
   },
   "peerDependencies": {
-    "react": ">=0.12.0"
+    "react": ">=0.12.0 || 0.13.0-beta.1"
   },
   "devDependencies": {
     "browserify": "^8.1.1",


### PR DESCRIPTION
With `>=npm@2` it's impossible to use `react@1.13.0-beta1` as it fails to install (see https://github.com/npm/npm/issues/7330 for details)

This change resolves that issue.