### PR TITLE
make sure the `props` object is not mutated

### DIFF
--- a/component.js
+++ b/component.js
@@ -51,6 +51,7 @@ function factory (options) {
     }
 
     var create = function (key, props, statics) {
+      var _props;
       var inputCursor;
       var children = toArray(arguments).filter(React.isValidElement);
 
@@ -60,10 +61,6 @@ function factory (options) {
         key   = void 0;
       }
 
-      if (!props) {
-        props = { };
-      }
-
       // If passed props is just a cursor we box it by making
       // props with `props[_hiddenCursorField]` set to given `props` so that
       // render will know how to unbox it. Note that __singleCursor proprety
@@ -71,23 +68,25 @@ function factory (options) {
       // passed on with conflicting proprety name.
       if (_isCursor(props) || _isImmutable(props)) {
         inputCursor = props;
-        props = {};
-        props[_hiddenCursorField] = inputCursor;
+        _props = {};
+        _props[_hiddenCursorField] = inputCursor;
+      } else {
+        _props = assign({}, props);
       }
 
       if (!!statics && !props.statics) {
-        props.statics = statics;
+        _props.statics = statics;
       }
 
       if (key) {
-        props.key = key;
+        _props.key = key;
       }
 
       if (!!children.length) {
-        props.children = children;
+        _props.children = children;
       }
 
-      return React.createElement(Component, props);
+      return React.createElement(Component, _props);
     };
 
     create.jsx = Component;

--- a/tests/component-test.js
+++ b/tests/component-test.js
@@ -264,6 +264,22 @@ describe('component', function () {
       render(Component('myKey', { foo: 'hello' }));
     });
 
+    it('should not mutate the props passed', function (done) {
+      var mixins = [{ componentDidMount: done }];
+
+      var props = { foo: 'hello' };
+      var statics = { bar: 'world' };
+
+      var Component = component(mixins, function (data) {
+        data.should.have.property('foo');
+        data.foo.should.equal('hello');
+        props.should.not.have.property('statics');
+        return React.DOM.text(null, 'hello');
+      });
+
+      render(Component(props, statics));
+    });
+
     it('should get passed key and immutable cursor-objects', function (done) {
       var mixins = [{ componentDidMount: done }];
       var cursorInput = Cursor.from(Immutable.fromJS({ foo: 'hello' }), 'foo');


### PR DESCRIPTION
While working on omniscient-dom, I noticed that my tests `prop` object was being mutated.  `key`, `statics` and `children` were being attached and affecting later tests.  I've updated `create` to have local props that are extended by the passed `key`, `props`, `statics` and `children`.