### PR TITLE
make note about adjustements to isNode, note it in options and add some more tests

### DIFF
--- a/component.js
+++ b/component.js
@@ -43,6 +43,7 @@ module.exports = factory();
  *   shouldComponentUpdate: function(nextProps, nextState), // check update
  *   jsx: false, // whether or not to default to jsx components
  *   cursorField: '__singleCursor', // cursor property name to "unwrap" before passing in to render
+ *   isNode: function(propValue), // determines if propValue is a valid React node
  *
  *   // Passed on to `shouldComponentUpdate`
  *   isCursor: function(cursor), // check if prop is cursor
@@ -316,6 +317,7 @@ function flatten (array) {
  * or not. Can be numbers, strings, bools, and React Elements.
  *
  * React's isNode check from ReactPropTypes validator
+ * but adjusted to not accept objects to avoid collision with props & statics.
  *
  * @param {String} propValue Property value to check if is valid React Node
  *
@@ -335,11 +337,6 @@ function isNode (propValue) {
       }
       if (React.isValidElement(propValue)) {
         return true;
-      }
-      for (var k in propValue) {
-        if (!isNode(propValue[k])) {
-          return false;
-        }
       }
       return false;
     default:

--- a/component.js
+++ b/component.js
@@ -196,7 +196,9 @@ function factory (options) {
         _props = assign({}, props);
       }
 
-      if (!!statics && !props.statics) {
+      // If statics is a node (due to it being optional)
+      // don't attach the node to the statics prop
+      if (!!statics && !props.statics && !_isNode(statics)) {
         _props.statics = statics;
       }
 

--- a/tests/component-test.js
+++ b/tests/component-test.js
@@ -484,6 +484,27 @@ describe('component', function () {
 
       render(Component('myKey', {}, outerStatics, c1));
     });
+
+    it('does not attach a node as props.statics', function (done) {
+      var mixins = [{ componentDidMount: done }];
+
+      var statics = { foo: 'bar' };
+
+      var c1 = ['hello', 'world'];
+
+      var Component = component(mixins, function (cursor) {
+        this.props.should.not.have.property('statics');
+
+        this.props.children.should.have.length(2);
+
+        this.props.children[0].should.equal(c1[0]);
+        this.props.children[1].should.equal(c1[1]);
+
+        return React.DOM.text(null, this.props.children);
+      });
+
+      render(Component({}, c1));
+    });
   });
 
   describe('overridables', function () {

--- a/tests/component-test.js
+++ b/tests/component-test.js
@@ -442,6 +442,48 @@ describe('component', function () {
 
       render(Component(outerCursor, c1));
     });
+
+    it('can take props, statics & children', function (done) {
+      var mixins = [{ componentDidMount: done }];
+
+      var statics = { foo: 'bar' };
+
+      var c1 = ['hello', 'world'];
+
+      var Component = component(mixins, function (cursor) {
+        this.props.children.should.have.length(2);
+
+        this.props.children[0].should.equal(c1[0]);
+        this.props.children[1].should.equal(c1[1]);
+
+        return React.DOM.text(null, this.props.children);
+      });
+
+      render(Component({}, statics, c1));
+    });
+
+    it('can take key, props, statics & children', function (done) {
+      var mixins = [{ componentDidMount: done }];
+
+      var outerStatics = { foo: 'bar' };
+
+      var c1 = ['hello', 'world'];
+
+      var Component = component(mixins, function (cursor, statics) {
+        hasKey(this, 'myKey');
+
+        statics.should.deep.equal(outerStatics);
+
+        this.props.children.should.have.length(2);
+
+        this.props.children[0].should.equal(c1[0]);
+        this.props.children[1].should.equal(c1[1]);
+
+        return React.DOM.text(null, this.props.children);
+      });
+
+      render(Component('myKey', {}, outerStatics, c1));
+    });
   });
 
   describe('overridables', function () {


### PR DESCRIPTION
I was thinking about the functionality I added and if I hadn't made the object -> false change, `statics` would have been treated as a child.  I added some more tests to make sure that doesn't happen, removed unnecessary object iteration since objects are treated as non-nodes and added some inline docs.