### PR TITLE
shouldComponentUpdate should handle prop change from cursor to non-cursor without throwing TypeError

### DIFF
--- a/shouldupdate.js
+++ b/shouldupdate.js
@@ -109,8 +109,17 @@ function factory (methods) {
     current = filter(current, _isCursor);
     next = filter(next, _isCursor);
 
+    var currentObj, nextObj;
     for (var key in current) {
-      if (!_isEqualCursor(current[key], next[key])) {
+      currentObj = current[key];
+      nextObj = next[key];
+      // filtering for cursors could cause a
+      // property to become undefined
+      if (typeof currentObj === 'undefined' ||
+          typeof nextObj === 'undefined') {
+        return true;
+      }
+      if (!_isEqualCursor(currentObj, nextObj)) {
         return true;
       }
     }

--- a/tests/shouldComponentUpdate-test.js
+++ b/tests/shouldComponentUpdate-test.js
@@ -21,6 +21,16 @@ describe('shouldComponentUpdate', function () {
       });
     });
 
+    it('when a cursor changes to a non-cursor', function () {
+      var data = Immutable.fromJS({ foo: 'bar', bar: [1, 2, 3] });
+      var data2 = Immutable.fromJS({ foo: 'cat', bar: [1, 2, 3] });
+
+      shouldUpdate({
+        cursor: { 'one': Cursor.from(data, ['foo']) },
+        nextCursor: { 'one': data2 }
+      });
+    });
+
     it('when there\'s suddenly a cursor', function () {
       var data = Immutable.fromJS({ foo: 'bar', bar: [1, 2, 3] });
 


### PR DESCRIPTION
If a property changes from a cursor to a non-cursor, shouldComponentUpdate (specifically hasChangedCursor) throws a TypeError

```
TypeError: Cannot read property 'deref' of undefined
      at unCursor (/Users/jeff/projects/omniscient/shouldupdate.js:266:16)
      at isEqualCursor (/Users/jeff/projects/omniscient/shouldupdate.js:202:29)
      at hasChangedCursors (/Users/jeff/projects/omniscient/shouldupdate.js:113:12)
      at Object.shouldComponentUpdate (/Users/jeff/projects/omniscient/shouldupdate.js:88:9)
```

The problem occurs because hasChangedCursors first filters the properties for the cursors but does't take into account that this could cause a property to become undefined in one of them. The fix is to check whether the property is undefined before passing into _isEqualCursor. I use transient variables for the property values to prevent multiple hits to find the value before checking undefined and passing to _isEqualCursor.

I created a failing test and the proposed fix.