### PR TITLE
relax react peerDep to allow react@0.13.0-rc1

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "lodash.pick": "^3.0.0"
   },
   "peerDependencies": {
-    "react": ">=0.12.0 || 0.13.0-beta.1"
+    "react": ">=0.12.0 || >=0.13.0-beta"
   },
   "devDependencies": {
     "browserify": "^8.1.1",


### PR DESCRIPTION
Now that there are new React.js 0.13 versions, we should relax the peer dependency in package.json so they can be used. 

npm view react

```
    '0.13.0-beta.1': '2015-01-28T05:19:01.230Z',
     '0.13.0-beta.2': '2015-02-14T02:37:43.316Z',
     '0.13.0-rc1': '2015-02-22T21:36:01.461Z' },
```

I believe `>=0.13.0-beta` should work
