### PR TITLE
Simplifies shouldComponentUpdate (open discussion)

### DIFF
--- a/shouldupdate.js
+++ b/shouldupdate.js
@@ -107,8 +107,8 @@ function factory (methods) {
    */
   function isEqualState (value, other) {
     return isEqual(value, other, function (current, next) {
-      if (current == next) return true;
-      return compare(current, next, _isImmutable);
+      if (current === next) return true;
+      return compare(current, next, _isImmutable, isEqualImmutable);
     });
   }
 
@@ -127,12 +127,12 @@ function factory (methods) {
    */
   function isEqualProps (value, other) {
     return isEqual(value, other, function (current, next) {
-      if (current == next) return true;
+      if (current === next) return true;
 
-      var cursorsEqual = compare(current, next, _isCursor);
+      var cursorsEqual = compare(current, next, _isCursor, _isEqualCursor);
       if (cursorsEqual !== void 0) return cursorsEqual;
 
-      return compare(current, next, _isImmutable);
+      return compare(current, next, _isImmutable, isEqualImmutable);
     });
   }
 
@@ -184,17 +184,21 @@ function factory (methods) {
   }
 }
 
-function compare (current, next, comparator) {
-  var isCurrentImmutable = comparator(current);
-  var isNextImmutable = comparator(next);
+function compare (current, next, comparator, equalCheck) {
+  var isCurrent = comparator(current);
+  var isNext = comparator(next);
 
-  if (isCurrentImmutable && isNextImmutable) {
-    return current === next;
+  if (isCurrent && isNext) {
+    return equalCheck(current, next);
   }
-  if (isCurrentImmutable || isCurrentImmutable) {
+  if (isCurrent || isCurrent) {
     return false;
   }
   return void 0;
+}
+
+function isEqualImmutable (a, b) {
+  return a === b;
 }
 
 /**

--- a/shouldupdate.js
+++ b/shouldupdate.js
@@ -69,7 +69,7 @@ function factory (methods) {
   return shouldComponentUpdate;
 
   function shouldComponentUpdate (nextProps, nextState) {
-    if (nextProps === this.props) {
+    if (nextProps === this.props && nextState === this.state) {
       if (debug) debug.call(this, 'shouldComponentUpdate => false (equal input)');
       return false;
     }

--- a/shouldupdate.js
+++ b/shouldupdate.js
@@ -184,9 +184,9 @@ function factory (methods) {
   }
 }
 
-function compare (current, next, comparator, equalCheck) {
-  var isCurrent = comparator(current);
-  var isNext = comparator(next);
+function compare (current, next, typeCheck, equalCheck) {
+  var isCurrent = typeCheck(current);
+  var isNext = typeCheck(next);
 
   if (isCurrent && isNext) {
     return equalCheck(current, next);

--- a/shouldupdate.js
+++ b/shouldupdate.js
@@ -74,13 +74,13 @@ function factory (methods) {
       return false;
     }
 
-    var nextProps    = filter(nextProps, isNotIgnorable),
-        currentProps = filter(this.props, isNotIgnorable);
-
     if (!_isEqualState(this.state, nextState)) {
       if (debug) debug.call(this, 'shouldComponentUpdate => true (state has changed)');
       return true;
     }
+
+    var nextProps    = filter(nextProps, isNotIgnorable),
+        currentProps = filter(this.props, isNotIgnorable);
 
     if (!_isEqualProps(currentProps, nextProps)) {
       if (debug) debug.call(this, 'shouldComponentUpdate => true (props have changed)');

--- a/tests/debug-test.js
+++ b/tests/debug-test.js
@@ -185,7 +185,7 @@ describe('debug', function () {
 
       var localComp = shouldComponentUpdate.withDefaults();
       localComp.debug(function logger (message) {
-        message.should.contain('true (number of cursors differ)');
+        message.should.contain('true (props have changed)');
         done();
       });
 
@@ -207,7 +207,7 @@ describe('debug', function () {
 
       var localComp = shouldComponentUpdate.withDefaults();
       localComp.debug(function logger (message) {
-        message.should.contain('true (cursors have different keys)');
+        message.should.contain('true (props have changed)');
         done();
       });
 
@@ -228,7 +228,7 @@ describe('debug', function () {
 
       var localComp = shouldComponentUpdate.withDefaults();
       localComp.debug(function logger (message) {
-        message.should.contain('true (cursors have changed)');
+        message.should.contain('true (props have changed)');
         done();
       });
 
@@ -254,7 +254,7 @@ describe('debug', function () {
     it('should log on properties have changed', function (done) {
       var localComp = shouldComponentUpdate.withDefaults();
       localComp.debug(function logger (message) {
-        message.should.contain('true (properties have changed)');
+        message.should.contain('true (props have changed)');
         done();
       });
 

--- a/tests/shouldComponentUpdate-test.js
+++ b/tests/shouldComponentUpdate-test.js
@@ -88,14 +88,14 @@ describe('shouldComponentUpdate', function () {
     it('when state have immutable structures', function () {
       shouldUpdate({
         state: { foo: Immutable.List.of(1) },
-        nextState: { foo: Immutable.List.of(1) },
+        nextState: { foo: Immutable.List.of(2) },
       });
     });
 
     it('when props have immutable structures', function () {
       shouldUpdate({
         cursor: { foo: Immutable.List.of(1) },
-        nextCursor: { foo: Immutable.List.of(1) },
+        nextCursor: { foo: Immutable.List.of(2) },
       });
     });
 
@@ -280,10 +280,10 @@ describe('shouldComponentUpdate', function () {
       it('should have overridable isEqualCursor', function (done) {
         var data = Immutable.fromJS({ foo: 'bar', bar: [1, 2, 3] });
         var local = component.withDefaults({
-          isEqualCursor: function () { done() }
+          isEqualCursor: function () { done(); return true; }
         }).shouldComponentUpdate;
 
-        shouldUpdate({
+        shouldNotUpdate({
           cursor: Cursor.from(data, ['foo']),
           nextCursor: Cursor.from(data, ['bar'])
         }, local);
@@ -333,13 +333,13 @@ describe('shouldComponentUpdate', function () {
         localComponent.debug.should.be.a('function');
       });
 
-      it('should have overridable isEqualCursor', function (done) {
+      it('should have overridable isEqualCursor', function () {
         var data = Immutable.fromJS({ foo: 'bar', bar: [1, 2, 3] });
         var local = shouldComponentUpdate.withDefaults({
-          isEqualCursor: function () { done() }
+          isEqualCursor: function () { return true; }
         });
 
-        shouldUpdate({
+        shouldNotUpdate({
           cursor: Cursor.from(data, ['foo']),
           nextCursor: Cursor.from(data, ['bar'])
         }, local);


### PR DESCRIPTION
Simplifications to `shouldComponentUpdate` now as we have `_.isEqual`. 

Started implementation based on some comments from #76 - and this is a continuation of the discussion. Not yet implemented "rebase" support. As that may be a separate change.

 Nor is comparable implemented. As there are some discussion if we need to do deep equal on immutable structures that has been said to not be equal through reference checks.