### PR TITLE
Treat cursors as transparent type by accessing internal value through `valueOf`

### DIFF
--- a/component.js
+++ b/component.js
@@ -46,9 +46,6 @@ module.exports = factory();
  *   isNode: function(propValue), // determines if propValue is a valid React node
  *
  *   // Passed on to `shouldComponentUpdate`
- *   isCursor: function(cursor), // check if prop is cursor
- *   unCursor: function (cursor), // convert cursor to object
- *   isEqualCursor: function (oneCursor, otherCursor), // compares cursor
  *   isEqualState: function (currentState, nextState), // compares state
  *   isEqualProps: function (currentProps, nextProps), // compares props
  *   isImmutable: function (maybeImmutable) // check if object is immutable
@@ -97,7 +94,7 @@ function factory (options) {
   options = options || {};
   var _shouldComponentUpdate = options.shouldComponentUpdate ||
                                shouldComponentUpdate.withDefaults(options);
-  var _isCursor = options.isCursor || shouldComponentUpdate.isCursor;
+  var _isCursor = options.isCursor || isCursor;
   var _isImmutable = options.isImmutable || shouldComponentUpdate.isImmutable;
   var _isJsx = !!options.jsx;
   var _hiddenCursorField = options.cursorField || '__singleCursor';
@@ -128,6 +125,7 @@ function factory (options) {
    */
   ComponentCreator.debug = debugFn;
   ComponentCreator.shouldComponentUpdate = _shouldComponentUpdate;
+  ComponentCreator.isCursor = _isCursor;
   return ComponentCreator;
 
   function ComponentCreator (displayName, mixins, render) {
@@ -408,3 +406,17 @@ function componentWillReceiveProps (newProps) {
 componentWillReceiveProps.asMixin = {
   componentWillReceiveProps: componentWillReceiveProps
 };
+
+/**
+ * Predicate to check if `potential` is Immutable cursor or not (defaults to duck testing
+ * Immutable.js cursors). Can override through `options.isCursor`.
+ *
+ * @param {potential} potential to check if is cursor
+ *
+ * @module shouldComponentUpdate.isCursor
+ * @returns {Boolean}
+ * @api public
+ */
+function isCursor (potential) {
+  return !!(potential && typeof potential.deref === 'function');
+}

--- a/shouldupdate.js
+++ b/shouldupdate.js
@@ -12,10 +12,8 @@ var isNotIgnorable = not(or(isStatics, isChildren));
  * @param {Object} nextProps Next props. Can be objects of cursors, values or immutable structures
  * @param {Object} nextState Next state. Can be objects of values or immutable structures
  *
- * @property {Function} isCursor Get default isCursor
  * @property {Function} isEqualState Get default isEqualState
  * @property {Function} isEqualProps Get default isEqualProps
- * @property {Function} isEqualCursor Get default isEqualCursor
  * @property {Function} isImmutable Get default isImmutable
  * @property {Function} debug Get default debug
  *
@@ -31,12 +29,9 @@ module.exports = factory();
  * ### Options
  * ```js
  * {
- *   isCursor: function(cursor), // check if is props
- *   isEqualCursor: function (oneCursor, otherCursor), // check cursor
  *   isEqualState: function (currentState, nextState), // check state
  *   isImmutable: function (currentState, nextState), // check if object is immutable
  *   isEqualProps: function (currentProps, nextProps), // check props
- *   unCursor: function (cursor) // convert from cursor to object
  * }
  * ```
  *
@@ -52,17 +47,12 @@ function factory (methods) {
   var debug;
   methods = methods || {};
 
-  var _isCursor      = methods.isCursor || isCursor,
-      _isEqualCursor = methods.isEqualCursor || isEqualCursor,
+  var _isImmutable   = methods.isImmutable || isImmutable,
       _isEqualState  = methods.isEqualState || isEqualState,
-      _isEqualProps  = methods.isEqualProps || isEqualProps,
-      _isImmutable   = methods.isImmutable || isImmutable,
-      _unCursor      = methods.unCursor || unCursor;
+      _isEqualProps  = methods.isEqualProps || isEqualProps;
 
-  shouldComponentUpdate.isCursor = _isCursor;
   shouldComponentUpdate.isEqualState = _isEqualState;
   shouldComponentUpdate.isEqualProps = _isEqualProps;
-  shouldComponentUpdate.isEqualCursor = _isEqualCursor;
   shouldComponentUpdate.isImmutable = _isImmutable;
   shouldComponentUpdate.debug = debugFn;
 
@@ -106,9 +96,8 @@ function factory (methods) {
    * @api public
    */
   function isEqualState (value, other) {
-    return isEqual(value, other, function (current, next) {
-      if (current === next) return true;
-      return compare(current, next, _isImmutable, isEqualImmutable);
+    return isEqual(value, other, function() {
+      return compareValueOf.apply(shouldComponentUpdate, arguments);
     });
   }
 
@@ -126,30 +115,9 @@ function factory (methods) {
    * @api public
    */
   function isEqualProps (value, other) {
-    return isEqual(value, other, function (current, next) {
-      if (current === next) return true;
-
-      var cursorsEqual = compare(current, next, _isCursor, _isEqualCursor);
-      if (cursorsEqual !== void 0) return cursorsEqual;
-
-      return compare(current, next, _isImmutable, isEqualImmutable);
+    return isEqual(value, other, function() {
+      return compareValueOf.apply(shouldComponentUpdate, arguments);
     });
-  }
-
-  /**
-   * Predicate to check if cursors are equal through reference checks. Uses `unCursor`.
-   * Override through `shouldComponentUpdate.withDefaults` to support different cursor
-   * implementations.
-   *
-   * @param {Cursor} a
-   * @param {Cursor} b
-   *
-   * @module shouldComponentUpdate.isEqualCursor
-   * @returns {Boolean}
-   * @api public
-   */
-  function isEqualCursor (a, b) {
-    return _unCursor(a) === _unCursor(b);
   }
 
   function debugFn (pattern, logFn) {
@@ -184,21 +152,29 @@ function factory (methods) {
   }
 }
 
-function compare (current, next, typeCheck, equalCheck) {
-  var isCurrent = typeCheck(current);
-  var isNext = typeCheck(next);
+function compareValueOf (current, next) {
+  if (current === next) return true;
+  if (!current || !next) return;
 
-  if (isCurrent && isNext) {
-    return equalCheck(current, next);
+  var currentValue = current.valueOf();
+  var nextValue = next.valueOf();
+
+  if(currentValue === nextValue) {
+    return true;
   }
-  if (isCurrent || isCurrent) {
+
+  if(current !== currentValue || next !== nextValue) {
     return false;
   }
-  return void 0;
-}
 
-function isEqualImmutable (a, b) {
-  return a === b;
+  if(typeof currentValue !== 'object' || typeof nextValue !== 'object') {
+    return false;
+  }
+
+  if(this.isImmutable(currentValue) || this.isImmutable(nextValue)) {
+    return false;
+  }
+
 }
 
 /**
@@ -217,35 +193,6 @@ function isImmutable(maybeImmutable) {
   return !!(maybeImmutable && maybeImmutable[IS_ITERABLE_SENTINEL]);
 }
 
-/**
- * Transforming function to take in cursor and return a non-cursor.
- * Override through `shouldComponentUpdate.withDefaults` to support different cursor
- * implementations.
- *
- * @param {cursor} cursor to transform
- *
- * @module shouldComponentUpdate.unCursor
- * @returns {Object|Number|String|Boolean}
- * @api public
- */
-function unCursor(cursor) {
-  if (!cursor || !cursor.deref) return cursor;
-  return cursor.deref();
-}
-
-/**
- * Predicate to check if `potential` is Immutable cursor or not (defaults to duck testing
- * Immutable.js cursors). Can override through `.withDefaults()`.
- *
- * @param {potential} potential to check if is cursor
- *
- * @module shouldComponentUpdate.isCursor
- * @returns {Boolean}
- * @api public
- */
-function isCursor (potential) {
-  return !!(potential && typeof potential.deref === 'function');
-}
 
 function not (fn) {
   return function () {

--- a/shouldupdate.js
+++ b/shouldupdate.js
@@ -159,19 +159,20 @@ function compareValueOf (current, next) {
   var currentValue = current.valueOf();
   var nextValue = next.valueOf();
 
-  if(currentValue === nextValue) {
-    return true;
-  }
+  if (currentValue === nextValue) return true;
 
-  if(current !== currentValue || next !== nextValue) {
+  // bail early on primitive types
+  if (typeof currentValue !== 'object' || typeof nextValue !== 'object') {
     return false;
   }
 
-  if(typeof currentValue !== 'object' || typeof nextValue !== 'object') {
+  // If condition is true, then current or next may be cursors.
+  // So we bail early here.
+  if (current !== currentValue || next !== nextValue) {
     return false;
   }
 
-  if(this.isImmutable(currentValue) || this.isImmutable(nextValue)) {
+  if (this.isImmutable(currentValue) || this.isImmutable(nextValue)) {
     return false;
   }
 

--- a/tests/component-test.js
+++ b/tests/component-test.js
@@ -542,7 +542,7 @@ describe('component', function () {
         isCursor: isCursor
       });
 
-      localComponent.shouldComponentUpdate.isCursor.should.equal(isCursor);
+      localComponent.isCursor.should.equal(isCursor);
       var Component = localComponent(function () {
         return React.DOM.text(null, 'hello');
       });

--- a/tests/debug-test.js
+++ b/tests/debug-test.js
@@ -12,7 +12,7 @@ var Cursor = require('immutable/contrib/cursor');
 
 var component = require('../');
 var shouldComponentUpdate = require('../shouldupdate');
-var isCursor = shouldComponentUpdate.isCursor;
+var isCursor = component.isCursor;
 
 describe('debug', function () {
   describe('api', function () {

--- a/tests/shouldComponentUpdate-test.js
+++ b/tests/shouldComponentUpdate-test.js
@@ -13,11 +13,16 @@ describe('shouldComponentUpdate', function () {
   describe('should update', function () {
 
     it('when cursors are different', function () {
-      var data = Immutable.fromJS({ foo: 'bar', bar: [1, 2, 3] });
+      var data = Immutable.Map({ foo: {}, bar: [1, 2, 3] });
 
       shouldUpdate({
         cursor: Cursor.from(data, ['foo']),
         nextCursor: Cursor.from(data, ['bar'])
+      });
+
+      shouldUpdate({
+        cursor: { foo: Cursor.from(data, ['foo'])},
+        nextCursor: {foo: { 'a': 32}}
       });
     });
 

--- a/tests/shouldComponentUpdate-test.js
+++ b/tests/shouldComponentUpdate-test.js
@@ -6,7 +6,7 @@ var Cursor = require('immutable/contrib/cursor');
 
 var component = require('../');
 var shouldComponentUpdate = require('../shouldupdate');
-var isCursor = shouldComponentUpdate.isCursor;
+var isCursor = component.isCursor;
 
 describe('shouldComponentUpdate', function () {
 
@@ -28,6 +28,15 @@ describe('shouldComponentUpdate', function () {
       shouldUpdate({
         cursor: { 'one': Cursor.from(data, ['foo']) },
         nextCursor: { 'one': data2 }
+      });
+    });
+
+    it('when passing cursor and non-cursor that do have the same value', function () {
+      var data = Immutable.fromJS({ foo: 'bar' });
+
+      shouldUpdate({
+        cursor: { one: Cursor.from(data, ['foo']) },
+        nextCursor: { one: 'foo' }
       });
     });
 
@@ -97,6 +106,11 @@ describe('shouldComponentUpdate', function () {
       shouldUpdate({
         state: { foo: 'hello' },
         nextState: { foo: 'bar' }
+      });
+
+      shouldUpdate({
+        state: { foo: 'hello' },
+        nextState: { foo: {} }
       });
     });
 
@@ -260,6 +274,15 @@ describe('shouldComponentUpdate', function () {
       });
     });
 
+    it('when passing cursor and non-cursor that have the same value', function () {
+      var data = Immutable.fromJS({ foo: 'bar' });
+
+      shouldNotUpdate({
+        cursor: { one: Cursor.from(data, ['foo']) },
+        nextCursor: { one: 'bar' }
+      });
+    });
+
     it('when multiple cursors point to the same data', function () {
       var data = Immutable.fromJS({ foo: 'bar', bar: [1, 2, 3] });
       var data2 = Immutable.fromJS({ baz: [1, 2, 3] });
@@ -296,33 +319,6 @@ describe('shouldComponentUpdate', function () {
   describe('overridables', function () {
 
     describe('through main component', function () {
-      it('should have overridable isCursor', function (done) {
-        var data = Immutable.fromJS({ foo: 'bar', bar: [1, 2, 3] });
-        var called = 0;
-        var local = component.withDefaults({
-          isCursor: function () { called++; return true; }
-        }).shouldComponentUpdate;
-
-        shouldUpdate({
-          cursor: Cursor.from(data, ['foo']),
-          nextCursor: Cursor.from(data, ['bar'])
-        }, local);
-
-        called.should.be.above(1);
-        done();
-      });
-
-      it('should have overridable isEqualCursor', function (done) {
-        var data = Immutable.fromJS({ foo: 'bar', bar: [1, 2, 3] });
-        var local = component.withDefaults({
-          isEqualCursor: function () { done(); return true; }
-        }).shouldComponentUpdate;
-
-        shouldNotUpdate({
-          cursor: Cursor.from(data, ['foo']),
-          nextCursor: Cursor.from(data, ['bar'])
-        }, local);
-      });
 
       it('should have overridable isEqualState', function (done) {
         var local = component.withDefaults({
@@ -345,39 +341,11 @@ describe('shouldComponentUpdate', function () {
         localOne.should.not.equal(localTwo);
       });
 
-      it('should have overridable isCursor', function (done) {
-        var data = Immutable.fromJS({ foo: 'bar', bar: [1, 2, 3] });
-        var called = 0;
-        var local = shouldComponentUpdate.withDefaults({
-          isCursor: function () { called++; return true; }
-        });
-
-        shouldUpdate({
-          cursor: Cursor.from(data, ['foo']),
-          nextCursor: Cursor.from(data, ['bar'])
-        }, local);
-
-        called.should.be.above(1);
-        done();
-      });
-
       it('should have debug on product of withDefaults', function () {
         var localComponent = shouldComponentUpdate.withDefaults({
           isCursor: function () { }
         });
         localComponent.debug.should.be.a('function');
-      });
-
-      it('should have overridable isEqualCursor', function () {
-        var data = Immutable.fromJS({ foo: 'bar', bar: [1, 2, 3] });
-        var local = shouldComponentUpdate.withDefaults({
-          isEqualCursor: function () { return true; }
-        });
-
-        shouldNotUpdate({
-          cursor: Cursor.from(data, ['foo']),
-          nextCursor: Cursor.from(data, ['bar'])
-        }, local);
       });
 
       it('should have overridable isImmutable', function (done) {
@@ -410,19 +378,15 @@ describe('shouldComponentUpdate', function () {
         }, local);
       });
 
-      it('should have accessible helpers (isCursor, isEqualState, isEqualProps, isEqualCursor) to use externally', function () {
+      it('should have accessible helpers (isEqualState, isEqualProps, isImmutable) to use externally', function () {
         var local = shouldComponentUpdate.withDefaults();
 
         shouldComponentUpdate.should.have.property('isEqualState');
-        shouldComponentUpdate.should.have.property('isCursor');
         shouldComponentUpdate.should.have.property('isEqualProps');
-        shouldComponentUpdate.should.have.property('isEqualCursor');
         shouldComponentUpdate.should.have.property('isImmutable');
 
         local.should.have.property('isEqualState');
-        local.should.have.property('isCursor');
         local.should.have.property('isEqualProps');
-        local.should.have.property('isEqualCursor');
         local.should.have.property('isImmutable');
       });
 


### PR DESCRIPTION
Building on https://github.com/omniscientjs/omniscient/pull/78

Treat cursors as transparent type by accessing internal value through `valueOf`

This is changes behaviour where the following is considered equivalent because their values are strictly compared:
- `Cursor.from(Immutable.fromJS({ foo: 'bar' }), ['foo'])`
- `'bar'`

---

Notes:
- `isCursor` method is moved to `component` since it's no longer used at `shouldComponentUpdate` level.
- https://gitter.im/omniscientjs/omniscient?at=54f59df7e172474214a811c7


## To Do

- [ ] Revise: https://gitter.im/omniscientjs/omniscient?at=54f59df7e172474214a811c7

--


Fixes #82 