### PR TITLE
Adds local class decorator extension

### DIFF
--- a/component.js
+++ b/component.js
@@ -116,105 +116,165 @@ function factory (initialOptions) {
   var _classDecorator = initialOptions.classDecorator || identity;
   var _cached = cached.withDefaults(_shouldComponentUpdate);
 
+  var CreatedComponent = ComponentCreatorFactory(_classDecorator);
+
   /**
-   * Activate debugging for components. Will log when a component renders,
-   * the outcome of `shouldComponentUpdate`, and why the component re-renders.
+   * Create components for functional views, with an attached local class decorator.
+   * Omniscient uses a `React.createClass()` internally to create an higher order
+   * component to attach performance boost and add some syntactic sugar to your
+   * components. Sometimes third party apps need to be added as decorator to this
+   * internal class. For instance Redux or Radium.
+   * This create factory behaves the same as normal Omniscient.js component
+   * creation, but with the additional first parameter for class decorator.
    *
-   * ### Example
-   * ```js
-   * Search>: shouldComponentUpdate => true (cursors have changed)
-   * Search>: render
-   * SearchBox>: shouldComponentUpdate => true (cursors have changed)
-   * SearchBox>: render
+   * The API of Omniscient is pretty simple, you create a Stateless React Component
+   * but memoized with a smart implemented `shouldComponentUpdate`.
+   *
+   * The provided `shouldComponentUpdate` handles immutable data and cursors by default.
+   * It also falls back to a deep value check if passed props isn't immutable structures.
+   *
+   * You can use an Omniscient component in the same way you'd use a React Stateless Function,
+   * or you can use some of the additional features, such as string defined display name and
+   * pass in life cycle methods. These are features normally not accessible for vanilla
+   * Stateless React Components.
+   *
+   * If you simply pass one cursor, the cursor will be accessible on the
+   * `props.cursor` accessor.
+   *
+   * #### Decorating class components
+   * ```jsx
+   * // Some third party libraries requires you to decorate the
+   * // React class, not the created component. You can do that
+   * // by creating a decorated component factory
+   * var someDecorator = compose(Radium, function (Component) {
+   *   var DecoratedComponent = doSomething(Component);
+   *   return DecoratedComponent;
+   * });
+   * var Component = component.withDecorator(someDecorator, function (props) {
+   *   // ... some implementation
+   * });
+   *
+   * React.render(<Component />, mountingPoint);
    * ```
    *
-   * @example omniscient.debug(/Search/i);
+   * @param {Function} classDecorator Decorator to use for internal class (e.g. Redux connect, Radium)
+   * @param {String} displayName Component's display name. Used when debug()'ing and by React
+   * @param {Array|Object} mixins React mixins. Object literals with functions, or array of object literals with functions.
+   * @param {Function} render Stateless component to add memoization on.
    *
-   * @param {RegExp} pattern Filter pattern. Only show messages matching pattern
-   *
-   * @module omniscient.debug
-   * @returns {Immstruct}
+   * @property {Function} shouldComponentUpdate Get default shouldComponentUpdate
+   * @module omniscient
+   * @returns {Component}
    * @api public
    */
-  ComponentCreator.debug = debugFn;
-  ComponentCreator.cached = _cached;
-  ComponentCreator.shouldComponentUpdate = _shouldComponentUpdate;
-  return ComponentCreator;
+  CreatedComponent.withDecorator = function (classDecorator, displayName, mixins, render) {
+    return ComponentCreatorFactory(classDecorator)(displayName, mixins, render);
+  };
+  return CreatedComponent;
 
-  function ComponentCreator (displayName, mixins, render) {
-    var options = createDefaultArguments(displayName, mixins, render);
-    var methodStatics = pickStaticMixins(options.mixins);
-
-    var componentObject = {
-      displayName: options.displayName || options.render.name,
-      mixins: options.mixins,
-      render: function render () {
-        if (debug) debug.call(this, 'render');
-        // If `props['__singleCursor']` is set a single cursor was passed
-        // to the component, pick it out and pass it.
-        var input = this.props[_hiddenCursorField] || this.props;
-        this.cursor = this.props[_hiddenCursorField];
-        return options.render.call(this, input);
-      }
-    };
-
-    if (methodStatics) {
-      componentObject.statics = methodStatics;
-      removeOldStaticMethods(options.mixins);
-    }
-
-    var Component = _classDecorator(React.createClass(componentObject));
+  function ComponentCreatorFactory (passedClassDecorator) {
 
     /**
-     * Invoke component (rendering it)
+     * Activate debugging for components. Will log when a component renders,
+     * the outcome of `shouldComponentUpdate`, and why the component re-renders.
      *
-     * @param {String} displayName Component display name. Used in debug and by React
-     * @param {Object} props Properties (triggers update when changed). Can be cursors, object and immutable structures
-     * @param {Object} ...rest Child components (React elements, scalar values)
+     * ### Example
+     * ```js
+     * Search>: shouldComponentUpdate => true (cursors have changed)
+     * Search>: render
+     * SearchBox>: shouldComponentUpdate => true (cursors have changed)
+     * SearchBox>: render
+     * ```
      *
-     * @module Component
-     * @returns {ReactElement}
+     * @example omniscient.debug(/Search/i);
+     *
+     * @param {RegExp} pattern Filter pattern. Only show messages matching pattern
+     *
+     * @module omniscient.debug
+     * @returns {Immstruct}
      * @api public
      */
-    var create = function (key, props) {
-      var _props;
-      var inputCursor;
-      var children;
+    ComponentCreator.debug = debugFn;
+    ComponentCreator.cached = _cached;
+    ComponentCreator.shouldComponentUpdate = _shouldComponentUpdate;
 
-      if (typeof key === 'object') {
-        props = key;
-        key   = void 0;
+    return ComponentCreator;
+
+    function ComponentCreator (displayName, mixins, render) {
+      var options = createDefaultArguments(displayName, mixins, render);
+      var methodStatics = pickStaticMixins(options.mixins);
+
+      var componentObject = {
+        displayName: options.displayName || options.render.name,
+        mixins: options.mixins,
+        render: function render () {
+          if (debug) debug.call(this, 'render');
+          // If `props['__singleCursor']` is set a single cursor was passed
+          // to the component, pick it out and pass it.
+          var input = this.props[_hiddenCursorField] || this.props;
+          this.cursor = this.props[_hiddenCursorField];
+          return options.render.call(this, input);
+        }
+      };
+
+      if (methodStatics) {
+        componentObject.statics = methodStatics;
+        removeOldStaticMethods(options.mixins);
       }
 
-      children = flatten(sliceFrom(arguments, props).filter(_isNode));
+      var Component = passedClassDecorator(React.createClass(componentObject));
 
-      // If passed props is a signle cursor we move it to `props[_hiddenCursorField]`
-      // to simplify should component update. The render function will move it back.
-      // The name '__singleCursor' is used to not clash with names of user passed properties
-      if (_isCursor(props) || _isImmutable(props)) {
-        inputCursor = props;
-        _props = {};
-        _props[_hiddenCursorField] = inputCursor;
-      } else {
-        _props = assign({}, props);
+      /**
+       * Invoke component (rendering it)
+       *
+       * @param {String} displayName Component display name. Used in debug and by React
+       * @param {Object} props Properties (triggers update when changed). Can be cursors, object and immutable structures
+       * @param {Object} ...rest Child components (React elements, scalar values)
+       *
+       * @module Component
+       * @returns {ReactElement}
+       * @api public
+       */
+      var create = function (key, props) {
+        var _props;
+        var inputCursor;
+        var children;
+
+        if (typeof key === 'object') {
+          props = key;
+          key   = void 0;
+        }
+
+        children = flatten(sliceFrom(arguments, props).filter(_isNode));
+
+        // If passed props is a signle cursor we move it to `props[_hiddenCursorField]`
+        // to simplify should component update. The render function will move it back.
+        // The name '__singleCursor' is used to not clash with names of user passed properties
+        if (_isCursor(props) || _isImmutable(props)) {
+          inputCursor = props;
+          _props = {};
+          _props[_hiddenCursorField] = inputCursor;
+        } else {
+          _props = assign({}, props);
+        }
+
+        if (key) {
+          _props.key = key;
+        }
+
+        if (!!children.length) {
+          _props.children = children;
+        }
+
+        return React.createElement(Component, _props);
+      };
+
+      if (methodStatics) {
+        create = assign(create, methodStatics);
       }
 
-      if (key) {
-        _props.key = key;
-      }
-
-      if (!!children.length) {
-        _props.children = children;
-      }
-
-      return React.createElement(Component, _props);
+      return create;
     };
-
-    if (methodStatics) {
-      create = assign(create, methodStatics);
-    }
-
-    return create;
   }
 
   function debugFn (pattern, logFn) {

--- a/tests/component-test.js
+++ b/tests/component-test.js
@@ -62,6 +62,21 @@ describe('component', function () {
       hasBeenCalled.should.equal(true);
     });
 
+    it('should attach inline decorator', function () {
+      var hasBeenCalled = false;
+      var decorator = function (SomeClass) {
+        hasBeenCalled = true;
+        return SomeClass;
+      };
+
+      var Component = component.withDecorator(decorator, function MyComponentName () {
+        return DOM.text(null, 'hello');
+      });
+
+      render(Component());
+      hasBeenCalled.should.equal(true);
+    });
+
     it('should allow to extend class as decorator', function () {
       var decorator = function (ComposedComponent) {
         ComposedComponent.displayName.should.equal('MyComponentName');
@@ -71,7 +86,7 @@ describe('component', function () {
       var decoratedComponent = component.withDefaults({
         classDecorator: decorator
       });
-      
+
       var Component = decoratedComponent(function MyComponentName () {
         this.constructor.displayName.should.equal('Foobar');
         return DOM.text(null, 'hello');


### PR DESCRIPTION
We see that there is some need to have local decorators per component as well as on component factory level. This PR adds class decorators to local components, such as:

```jsx
// Some third party libraries requires you to decorate the
// React class, not the created component. You can do that
// by creating a decorated component factory
var someDecorator = compose(Radium, function (Component) {
  var DecoratedComponent = doSomething(Component);
  return DecoratedComponent;
});
var Component = component.withDecorator(someDecorator, function (props) {
  // ... some implementation
});
React.render(<Component />, mountingPoint);
