### PR TITLE
Handle component creator's result being new'ed from within react 0.14, #123

### DIFF
--- a/component.js
+++ b/component.js
@@ -235,7 +235,21 @@ function factory (initialOptions) {
        * @returns {ReactElement}
        * @api public
        */
-      var create = function (key, props) {
+      var create = function (keyOrProps, propsOrPublicContext, ReactUpdateQueue) {
+
+        // After stateless arrow functions was allowed as components, react will instantiate
+        // the `create` function if it has a prototype. We are passed `props`, `publicContext`
+        // and `ReactUpdateQueue`.
+        // https://github.com/facebook/react/blob/88bae3fb73511893519195e451c56896463f669b/src/renderers/shared/reconciler/ReactCompositeComponent.js#L154-L171
+        if (typeof ReactUpdateQueue == 'object') {
+          var publicProps = keyOrProps;
+          var publicContext = propsOrPublicContext;
+          return new Component(publicProps, publicContext, ReactUpdateQueue);
+        }
+
+        var key = keyOrProps;
+        var props = propsOrPublicContext;
+
         var _props;
         var inputCursor;
         var children;

--- a/component.js
+++ b/component.js
@@ -241,9 +241,9 @@ function factory (initialOptions) {
         // the `create` function if it has a prototype. We are passed `props`, `publicContext`
         // and `ReactUpdateQueue`.
         // https://github.com/facebook/react/blob/88bae3fb73511893519195e451c56896463f669b/src/renderers/shared/reconciler/ReactCompositeComponent.js#L154-L171
-        if (typeof ReactUpdateQueue == 'object') {
           var publicProps = keyOrProps;
           var publicContext = propsOrPublicContext;
+        if (typeof ReactUpdateQueue == 'object' && !_isNode(ReactUpdateQueue)) {
           return new Component(publicProps, publicContext, ReactUpdateQueue);
         }
 

--- a/component.js
+++ b/component.js
@@ -275,7 +275,7 @@ function factory (initialOptions) {
           _props.key = key;
         }
 
-        if (!!children.length) {
+        if (children.length) {
           _props.children = children;
         }
 

--- a/component.js
+++ b/component.js
@@ -236,7 +236,6 @@ function factory (initialOptions) {
        * @api public
        */
       var create = function (keyOrProps, propsOrPublicContext, ReactUpdateQueue) {
-
         // After stateless arrow functions was allowed as components, react will instantiate
         // the `create` function if it has a prototype. We are passed `props`, `publicContext`
         // and `ReactUpdateQueue`.
@@ -288,7 +287,7 @@ function factory (initialOptions) {
       }
 
       return create;
-    };
+    }
   }
 
   function debugFn (pattern, logFn) {

--- a/component.js
+++ b/component.js
@@ -240,25 +240,24 @@ function factory (initialOptions) {
         // the `create` function if it has a prototype. We are passed `props`, `publicContext`
         // and `ReactUpdateQueue`.
         // https://github.com/facebook/react/blob/88bae3fb73511893519195e451c56896463f669b/src/renderers/shared/reconciler/ReactCompositeComponent.js#L154-L171
-          var publicProps = keyOrProps;
-          var publicContext = propsOrPublicContext;
         if (typeof ReactUpdateQueue == 'object' && !_isNode(ReactUpdateQueue)) {
+          var publicProps = keyOrProps,
+              publicContext = propsOrPublicContext;
           return new Component(publicProps, publicContext, ReactUpdateQueue);
         }
 
-        var key = keyOrProps;
-        var props = propsOrPublicContext;
-
-        var _props;
-        var inputCursor;
-        var children;
+        var key = keyOrProps,
+            props = propsOrPublicContext;
 
         if (typeof key === 'object') {
           props = key;
           key   = void 0;
         }
 
-        children = flatten(sliceFrom(arguments, props).filter(_isNode));
+        var children = flatten(sliceFrom(arguments, props).filter(_isNode));
+
+        var _props,
+            inputCursor;
 
         // If passed props is a signle cursor we move it to `props[_hiddenCursorField]`
         // to simplify should component update. The render function will move it back.

--- a/tests/component-test.js
+++ b/tests/component-test.js
@@ -5,7 +5,6 @@ var Cursor = require('immutable/contrib/cursor');
 
 var React = require('react');
 var ReactDOM = require('react-dom');
-var ReactDOMServer = require('react-dom/server');
 
 var DOM = React.DOM;
 var should = chai.should();

--- a/tests/component-test.js
+++ b/tests/component-test.js
@@ -5,6 +5,7 @@ var Cursor = require('immutable/contrib/cursor');
 
 var React = require('react');
 var ReactDOM = require('react-dom');
+var ReactDOMServer = require('react-dom/server');
 
 var DOM = React.DOM;
 var should = chai.should();
@@ -605,6 +606,18 @@ describe('component', function () {
 
       render(Component({ one: cursor1, two: cursor2 }));
     });
+  });
+
+  describe('as an element', function () {
+
+    it('should create react class instance, not an element, when passed `publicProps`, `publicContext`, and `ReactUpdateQueue`', function () {
+      var Component = component(function () {
+        return DOM.div();
+      });
+      React.isValidElement(Component()).should.be.true;
+      React.isValidElement(Component({}, {}, {})).should.be.false;
+    });
+
   });
 
   describe('should not re-render', function () {


### PR DESCRIPTION
A change in 0.14 results in our component creator's returned `create` function being new'ed from inside React, due to a naive check for handling stateless react components that are plain functions.

https://github.com/facebook/react/blob/88bae3fb73511893519195e451c56896463f669b/src/renderers/shared/reconciler/ReactCompositeComponent.js#L158

This change will return an instance of the react component instead of an element when a third argument that is not a child is passed to our component creator. 

Resolves #123.