### PR TITLE
Expose `type` on the component creator

### DIFF
--- a/component.js
+++ b/component.js
@@ -304,6 +304,8 @@ function factory (initialOptions) {
         create = assign(create, methodStatics);
       }
 
+      create.type = Component;
+
       return create;
     }
   }

--- a/tests/component-test.js
+++ b/tests/component-test.js
@@ -623,9 +623,9 @@ describe('component', function () {
     });
   });
 
-  describe('as an element', function () {
+  describe('creator disquises as a react class', function () {
 
-    it('should create react class instance, not an element, when passed `publicProps`, `publicContext`, and `ReactUpdateQueue`', function () {
+    it('creates react class instance, not an element, when passed `publicProps`, `publicContext`, and `ReactUpdateQueue`', function () {
       var Component = component(function () {
         return DOM.div();
       });
@@ -633,6 +633,16 @@ describe('component', function () {
       React.isValidElement(Component({}, {}, {})).should.be.false;
     });
 
+    it('exposes `type` on itself', function () {
+      var Type;
+      var comp = component.classDecorator(Class => Type = Class);
+
+      var Creator = comp(function () {
+        return DOM.div();
+      });
+
+      Creator.type.should.equal(Type);
+    });
   });
 
   describe('should not re-render', function () {


### PR DESCRIPTION
As of react 0.14 more and more libs (and react itself) seems less pleased with us [returning a component creator](https://github.com/omniscientjs/omniscient/blob/afd57675e3033ebd3b63951951103e066ef4bc52/component.js#L307) and not a react component class. We should keep this in mind going forward.. If we need much more of this kind of stuff I'm thinking we should probably reconsider?

This latest addition fixes an issue where react hot loader will no longer hot reload our components when their type is our component creator. This PR exposes the `type` our creator will create (when called) on the creator itself. 

Another approach resolving our issue with react hot loader would be adopting the `Component`s prototype, as the hot reloading patches it: `create.prototype = Component.prototype`