### PR TITLE
Expose `defaultProps` on component creator

### DIFF
--- a/component.js
+++ b/component.js
@@ -304,9 +304,7 @@ function factory (initialOptions) {
         create = assign(create, methodStatics);
       }
 
-      create.type = Component;
-
-      return create;
+      return assign(create, Component, { type: Component });
     }
   }
 

--- a/tests/component-test.js
+++ b/tests/component-test.js
@@ -643,6 +643,24 @@ describe('component', function () {
 
       Creator.type.should.equal(Type);
     });
+
+    it('will pass default props', function () {
+      var expectedPropValue = 'default-prop-value';
+
+      var lifecycleMethods = {
+        getDefaultProps: function () {
+          return { direction: expectedPropValue };
+        }
+      };
+      var Component = component(lifecycleMethods, function (props) {
+        should.equal(props.direction, expectedPropValue);
+        this.props.direction.should.equal(expectedPropValue);
+        return DOM.div();
+      });
+
+      render(Component());
+      render(React.createElement(Component)); // jsx
+    });
   });
 
   describe('should not re-render', function () {


### PR DESCRIPTION
More properties are required on our creator https://github.com/facebook/react/blob/0b29035484f428cb56e7e1c04a88f66ac020d1d4/src/isomorphic/classic/element/ReactElement.js#L151 I don't have a good feeling about this trend.. 

Anyhow, this fixes #126.