### PR TITLE
Use .equals() instead of === for immutable equality

### DIFF
--- a/shouldupdate.js
+++ b/shouldupdate.js
@@ -209,7 +209,7 @@ function compare (current, next, typeCheck, equalCheck) {
 }
 
 function isEqualImmutable (a, b) {
-  return a === b;
+  return a.equals(b);
 }
 
 /**

--- a/tests/shouldComponentUpdate-test.js
+++ b/tests/shouldComponentUpdate-test.js
@@ -182,18 +182,20 @@ describe('shouldComponentUpdate', function () {
     });
 
     it('when state have same immutable structures', function () {
-      var map = Immutable.List.of(1);
+      var map1 = Immutable.List.of(1);
+      var map2 = Immutable.List.of(1);
       shouldNotUpdate({
-        state: { foo: map },
-        nextState: { foo: map }
+        state: { foo: map1 },
+        nextState: { foo: map2 }
       });
     });
 
     it('when props have same immutable structures', function () {
-      var map = Immutable.List.of(1);
+      var map1 = Immutable.List.of(1);
+      var map2 = Immutable.List.of(1);
       shouldNotUpdate({
-        props: { foo: map },
-        nextProps: { foo: map }
+        props: { foo: map1 },
+        nextProps: { foo: map2 }
       });
     });
 


### PR DESCRIPTION
The === check for equality for immutable structures only works for cases where the actual reference is exactly the same, but not if they're the same by value.  So for example:

> var a = Immutable.Map();
> var b = a;
> a === b; // true

but

> var a = Immutable.Map();
> var b = Immutable.Map();
> a === b; // false
> a.equals(b); // true

This has been causing our `shouldComponentUpdate` fire with a `true` when our props have not changed.

This PR updates this behavior in the default `isEqualImmutable` check, and fixes the tests to check for this situation.
